### PR TITLE
corrige cluster_stat pra usernames longos

### DIFF
--- a/scripts/local_stat
+++ b/scripts/local_stat
@@ -11,7 +11,7 @@ echo -n "Mem use: $(echo $total $free $buffer $cache | awk '{printf("%5.1f", 100
 echo -n "		"
 # Jobs
 MYTTY=$(tty)
-job=`ps aux | grep -v "${MYTTY#/dev/}" | grep -v "systemd \-\-user" | grep -v "\(sd-pam\)" | awk '{ print $1 }' | sed '1 d' | sort | uniq | perl -e 'for (<>) { chomp; $u = ( getpwnam($_) )[2]; print $_, "\n" if ( ( $u >= 1000 ) && ( $_ =~ /[[:alpha:]]/ && $_ ne "nobody" ) ) }' | sed ':a;N;$!ba;s/\n/ /g'`
+job=`ps axo user:32,tty,comm | grep -v "${MYTTY#/dev/}" | grep -v "systemd \-\-user" | grep -v "\(sd-pam\)" | awk '{ print $1 }' | sed '1 d' | sort | uniq | perl -e 'for (<>) { chomp; $u = ( getpwnam($_) )[2]; print $_, "\n" if ( ( $u >= 1000 ) && ( $_ =~ /[[:alpha:]]/ && $_ ne "nobody" ) ) }' | sed ':a;N;$!ba;s/\n/ /g'`
 if [ "$job" != "" ]; then
 	echo -n "Jobs from: $job"
 fi


### PR DESCRIPTION
Fix #17 mudando o output do ps. Elimina outras colunas desnecessárias, e o 32 não é arbitrário, é o tamanho máximo de username (ver man useradd).

PS: testei o comando mas fiquei com preguiça de clonar e etc., o github tem esse esquema de editar o arquivo direto na interface web e talz, espero que não dê bobagem.